### PR TITLE
Using default branch for Heroku deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ qzl5kjhxrw73rcvr6ska3wzksu2vqsa20s4nt0ty8m
  
 ### Installation (Cloud) 🌩
  
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/Artis7eer/ForwardTagRemoverBot/tree/master)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/Artis7eer/ForwardTagRemoverBot/tree/main)
 
 <br/>
 


### PR DESCRIPTION
GitHub is using main as the default branch name instead of master. 
Heroku deployments will fail if the default branch is set to master.